### PR TITLE
Change the link for setup in the homepage

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -72,7 +72,7 @@ title: "webOS Open Source Edition"
       <div class="columns verticals">
         <div class="column">
           <div class="card">
-            <a href="{{< relref "system-requirements" >}}" class="">
+            <a href="{{< relref "/docs/guides#setup" >}}" class="">
               <header class="card-header">
                 {{% get-image src="/images/icon_setup.png" title="Setup icon image" %}}
               </header>


### PR DESCRIPTION
On the homepage, the link on "SETUP" is pointing to the System Requirements page. It would be better if this is linked to the "Setup" index under "Docs"-"Guides". 