### PR TITLE
Fix: missing content in parameters / errorcode

### DIFF
--- a/content/en/docs/reference/ls2-api/com-webos-service-db.html
+++ b/content/en/docs/reference/ls2-api/com-webos-service-db.html
@@ -4629,6 +4629,7 @@ This API has been available since [API level]({{< relref "ls2-api-index#api-leve
               <ul>
                 <li style="text-align:left">The service&#39;s bus address</li>
                 <li style="text-align:left">The app&#39;s app ID</li>
+                <li style="text-align:left">The service name</li>
               </ul>
               <p style="text-align:left">Only the owner has permission to modify the kind.</p>
             </td>
@@ -4763,6 +4764,13 @@ This API has been available since [API level]({{< relref "ls2-api-index#api-leve
             <td>db: invalid owner for kind</td>
             <td>
               <p style="text-align: left;">This message implies that the specified owner does not have permissions to add or modify the specified kind.&nbsp;<br></p>
+            </td>
+          </tr>
+          <tr>
+            <td>-3963</td>
+            <td>db: permission denied</td>
+            <td>
+              <p style="text-align: left;">TThis message implies that the app does not have permission to to create table for database. <br></p>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
- com.webos.service.db/putKind
- the values of 'owner' parameter should include service name
- the errorcode should include -3963

There was no description of service's bus address in the webOS OSE, so I referred to the webos TV developer.
"luna://com.palm.wifi/status" and "com.example.helloworld" are two examples of service's bus address.
From this point of view, it is estimated that **the address of the service provided by webOS** or **app ID** means **service's bus addres.**
[https://webostv.developer.lge.com/develop/references/webos-service-reference#servicebusid](url)

There is a description of the service in [Docs] -> [Reference] -> [com.webos.service.db]. Here, a value that can be an owner among Parameters in the putKind method is written as **app ID** or **service's bus address.**

As you know, the service name starts with the app ID. If the **app ID** is 'com.domain.app', the **service name** should be 'com.domain.app.service'. So, not only app ID, but also JS service that I named the service can make API calls.
This is where the problem comes from. The screenshot is an example of an error that the 'ls-monitor' tool has identified.

![scrennshot](https://github.com/webosose/website/assets/62577519/f2c5e315-0391-4410-b672-ca69575d4a36)

Therefore, it is argued that it should be able to be the **service name** among the owner of kind. Since the development is carried out by dividing Application Dir and JS service Dir, I think there will be more cases of calling the API through JS Service than directly calling the API from the APP. In relation to this, quite a few people are not finding the cause of the error even in [Community]. **In conclusion, the service name should also be added to the value that can be the owner of kind.**

In addition, {Error Code: -3963, Error Text: db: permission denied, Error Description: } should be added to the Error Codes Reference of the putKind method. As seen in the screenshot, it returns an **error code of -3963 as an error for using putKind.** The corresponding content is also not described, so a correction is required.

[https://www.webosose.org/docs/reference/ls2-api/com-webos-service-db/#putkind](url)

Thanks.

